### PR TITLE
Fix bug when datatables did not save state.

### DIFF
--- a/Resources/views/Crud/_generic_options.js.twig
+++ b/Resources/views/Crud/_generic_options.js.twig
@@ -1,8 +1,10 @@
 <script type="text/javascript">
 
     // Search for all columns where searchable = true
-    var searchText = datatable.state().search.search;
-    $(".searchText").val(searchText);
+    if (datatable.state()) {
+        var searchText = datatable.state().search.search;
+        $(".searchText").val(searchText);
+    }
 
     $( ".searchText" ).keyup(function() {
         datatable.search( this.value ).draw();


### PR DESCRIPTION
@stevergill had to make this change because if not, a JS error was thrown when you did not use `"stateSave": true` for datatables.